### PR TITLE
Multiple Language Support for the Spellcheck

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,28 +26,42 @@ dependencies {
 	modImplementation "fi.dy.masa.malilib:malilib-fabric-1.18.2:${project.malilib_version}"
 	modImplementation "com.github.DarkKronicle:AdvancedChatCore:${project.advancedchat_version}"
 
+	implementation "org.languagetool:language-de:5.5"
 	implementation "org.languagetool:language-en:5.5"
 	// Transitive
+	include "org.languagetool:language-de:5.5"
 	include "org.languagetool:language-en:5.5"
 	include "org.languagetool:languagetool-core:5.5"
-	include group: 'net.loomchild', name: 'segment', version: '2.0.3'
-	include group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
-	include group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
-	include group: 'org.jetbrains.intellij.deps', name: 'trove4j', version: '1.0.20200330'
-	include group: 'javax.measure', name: 'unit-api', version: '2.1.3'
-	include group: 'tech.units', name: 'indriya', version: '1.3'
+	
+	
+	
 	include group: 'tech.uom.lib', name: 'uom-lib-common', version: '1.1'
-	include group: 'org.carrot2', name: 'morfologik-fsa', version: '2.1.7'
-	include group: 'org.carrot2', name: 'morfologik-fsa-builders', version: '2.1.7'
-	include group: 'org.carrot2', name: 'morfologik-speller', version: '2.1.7'
-	include group: 'org.carrot2', name: 'morfologik-stemming', version: '2.1.7'
 	include group: 'org.apache.opennlp', name: 'opennlp-tools', version: '1.9.3'
 	include group: 'edu.washington.cs.knowitall', name: 'opennlp-chunk-models', version: '1.5'
 	include group: 'edu.washington.cs.knowitall', name: 'opennlp-postag-models', version: '1.5'
 	include group: 'edu.washington.cs.knowitall', name: 'opennlp-tokenize-models', version: '1.5'
 	include group: 'edu.washington.cs.knowitall', name: 'opennlp-chunk-models', version: '1.5'
 	include group: 'com.carrotsearch', name: 'hppc', version: '0.9.0'
-}
+	include group: 'de.danielnaber', name: 'german-pos-dict', version: '1.2.2'
+	include group: 'de.danielnaber', name: 'jwordsplitter', version: '4.5'
+	include group: 'edu.washington.cs.knowitall', name: 'openregex', version: '1.1.1'
+	include group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
+
+	include group: 'org.carrot2', name: 'morfologik-fsa', version: '2.1.7'
+	include group: 'org.carrot2', name: 'morfologik-fsa-builders', version: '2.1.7'
+	include group: 'org.carrot2', name: 'morfologik-speller', version: '2.1.7'
+	include group: 'org.carrot2', name: 'morfologik-stemming', version: '2.1.7'
+	include group: 'net.loomchild', name: 'segment', version: '2.0.3'
+	include group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'
+	include group: 'net.sf.trove4j', name: 'trove4j', version: '3.0.3'
+	include group: 'org.jetbrains.intellij.deps', name: 'trove4j', version: '1.0.20200330'
+	include group: 'javax.measure', name: 'unit-api', version: '2.1.3'
+	include group: 'tech.units', name: 'indriya', version: '1.3'
+
+	include group: 'com.hankcs', name: 'aho-corasick-double-array-trie', version: '1.2.2'
+        include group: 'com.gitlab.dumonts', name: 'hunspell', version: '1.1.1'
+        include group: 'com.nativelibs4java', name: 'bridj', version: '0.7.0'
+ } 
 
 processResources {
 	inputs.property "version", project.version

--- a/build.gradle
+++ b/build.gradle
@@ -28,13 +28,31 @@ dependencies {
 
 	implementation "org.languagetool:language-de:5.5"
 	implementation "org.languagetool:language-en:5.5"
+	implementation "org.languagetool:language-ru:5.5"
+	implementation "org.languagetool:language-zh:5.5"
+	implementation "org.languagetool:language-pt:5.5"
+	implementation "org.languagetool:language-fr:5.5"
+	implementation "org.languagetool:language-nl:5.5"
+	implementation "org.languagetool:language-pl:5.5"
+	implementation "org.languagetool:language-es:5.5"
+	implementation "org.languagetool:language-it:5.5"
+	implementation "org.languagetool:language-uk:5.5"
 	// Transitive
 	include "org.languagetool:language-de:5.5"
 	include "org.languagetool:language-en:5.5"
+	include "org.languagetool:language-ru:5.5"
+	include "org.languagetool:language-zh:5.5"
+	include "org.languagetool:language-pt:5.5"
+	include "org.languagetool:language-fr:5.5"
+	include "org.languagetool:language-nl:5.5"
+	include "org.languagetool:language-pl:5.5"
+	include "org.languagetool:language-es:5.5"
+	include "org.languagetool:language-it:5.5"
+	include "org.languagetool:language-uk:5.5"
 	include "org.languagetool:languagetool-core:5.5"
 	
 	
-	
+	//German and English
 	include group: 'tech.uom.lib', name: 'uom-lib-common', version: '1.1'
 	include group: 'org.apache.opennlp', name: 'opennlp-tools', version: '1.9.3'
 	include group: 'edu.washington.cs.knowitall', name: 'opennlp-chunk-models', version: '1.5'
@@ -46,7 +64,7 @@ dependencies {
 	include group: 'de.danielnaber', name: 'jwordsplitter', version: '4.5'
 	include group: 'edu.washington.cs.knowitall', name: 'openregex', version: '1.1.1'
 	include group: 'org.apache.commons', name: 'commons-lang3', version: '3.11'
-
+    
 	include group: 'org.carrot2', name: 'morfologik-fsa', version: '2.1.7'
 	include group: 'org.carrot2', name: 'morfologik-fsa-builders', version: '2.1.7'
 	include group: 'org.carrot2', name: 'morfologik-speller', version: '2.1.7'
@@ -61,6 +79,13 @@ dependencies {
 	include group: 'com.hankcs', name: 'aho-corasick-double-array-trie', version: '1.2.2'
         include group: 'com.gitlab.dumonts', name: 'hunspell', version: '1.1.1'
         include group: 'com.nativelibs4java', name: 'bridj', version: '0.7.0'
+	//Chinese
+	include group: 'com.google.code', name: 'cjftransform', version: '1.0.1'
+        include group: 'com.hankcs', name: 'hanlp', version: 'portable-1.7.8'
+        //Spanish
+        include group: 'org.softcatala', name: 'spanish-pos-dict', version: '1.3'    
+	//Ukrainian
+	include group: 'ua.net.nlp', name: 'morfologik-ukrainian-lt', version: '5.5.1'
  } 
 
 processResources {

--- a/src/main/java/io/github/darkkronicle/advancedchatbox/ChatBoxInitHandler.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatbox/ChatBoxInitHandler.java
@@ -72,6 +72,8 @@ public class ChatBoxInitHandler implements IInitializationHandler {
             suggestorRegistry.register(SpellCheckSuggestor::getInstance, "spellcheck",
                     "advancedchatbox.config.chatsuggestor.spellcheck",
                     "advancedchatbox.config.chatsuggestor.info.spellcheck", true, false);
+            SpellCheckSuggestor setup = new SpellCheckSuggestor();
+            setup.Setup();                      
         } catch (Exception e) {
             LogManager.getLogger().log(Level.ERROR, "[AdvancedChat] {}", "Couldn't load SpellCheckSuggestor", e);
         }

--- a/src/main/java/io/github/darkkronicle/advancedchatbox/ChatBoxInitHandler.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatbox/ChatBoxInitHandler.java
@@ -37,7 +37,6 @@ public class ChatBoxInitHandler implements IInitializationHandler {
     @Override
     public void registerModHandlers() {
         ChatBoxConfigStorage.getInstance().load(); 
-        System.out.println("HIER LADEN INIT HANDLER NACH OVERRIDE");  
         ConfigManager.getInstance().registerConfigHandler(AdvancedChatBox.MOD_ID, new ChatBoxConfigStorage());
         GuiConfigHandler.getInstance().addTab(GuiConfigHandler.children("box", "advancedchat.config.tab.advancedchatbox",
                 GuiConfigHandler.wrapScreen("box_general", "advancedchatbox.config.tab.general",

--- a/src/main/java/io/github/darkkronicle/advancedchatbox/ChatBoxInitHandler.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatbox/ChatBoxInitHandler.java
@@ -36,6 +36,8 @@ import org.apache.logging.log4j.LogManager;
 public class ChatBoxInitHandler implements IInitializationHandler {
     @Override
     public void registerModHandlers() {
+        ChatBoxConfigStorage.getInstance().load(); 
+        System.out.println("HIER LADEN INIT HANDLER NACH OVERRIDE");  
         ConfigManager.getInstance().registerConfigHandler(AdvancedChatBox.MOD_ID, new ChatBoxConfigStorage());
         GuiConfigHandler.getInstance().addTab(GuiConfigHandler.children("box", "advancedchat.config.tab.advancedchatbox",
                 GuiConfigHandler.wrapScreen("box_general", "advancedchatbox.config.tab.general",

--- a/src/main/java/io/github/darkkronicle/advancedchatbox/ChatBoxInitHandler.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatbox/ChatBoxInitHandler.java
@@ -72,8 +72,7 @@ public class ChatBoxInitHandler implements IInitializationHandler {
             suggestorRegistry.register(SpellCheckSuggestor::getInstance, "spellcheck",
                     "advancedchatbox.config.chatsuggestor.spellcheck",
                     "advancedchatbox.config.chatsuggestor.info.spellcheck", true, false);
-            SpellCheckSuggestor setup = new SpellCheckSuggestor();
-            setup.Setup();                      
+            SpellCheckSuggestor.getInstance().setup();                   
         } catch (Exception e) {
             LogManager.getLogger().log(Level.ERROR, "[AdvancedChat] {}", "Couldn't load SpellCheckSuggestor", e);
         }

--- a/src/main/java/io/github/darkkronicle/advancedchatbox/config/ChatBoxConfigStorage.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatbox/config/ChatBoxConfigStorage.java
@@ -78,6 +78,8 @@ public class ChatBoxConfigStorage implements IConfigHandler {
 
         public static final SaveableConfig<ConfigString> HOVER_TEXT = SaveableConfig.fromConfig("hoverText",
                 new ConfigString(translate("hovertext"), "&7$1&b$2&7$3", translate("info.hovertext")));
+        public static final SaveableConfig<ConfigString> SPELL_LANGUAGE = SaveableConfig.fromConfig("spellLanguage",
+                new ConfigString(translate("spellLanguage"), "German", translate("info.spellLanguage")));       
 
         // public static final SaveableConfig<ConfigBoolean>
         // SUGGEST_CAPITAL =
@@ -90,7 +92,7 @@ public class ChatBoxConfigStorage implements IConfigHandler {
         // )
         // );
 
-        public static final ImmutableList<SaveableConfig<? extends IConfigBase>> OPTIONS = ImmutableList.of(HOVER_TEXT
+        public static final ImmutableList<SaveableConfig<? extends IConfigBase>> OPTIONS = ImmutableList.of(HOVER_TEXT, SPELL_LANGUAGE
         // SUGGEST_CAPITAL
         );
     }

--- a/src/main/java/io/github/darkkronicle/advancedchatbox/config/ChatBoxConfigStorage.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatbox/config/ChatBoxConfigStorage.java
@@ -36,6 +36,12 @@ public class ChatBoxConfigStorage implements IConfigHandler {
     public static final String CONFIG_FILE_NAME = AdvancedChatBox.MOD_ID + ".json";
     private static final int CONFIG_VERSION = 1;
 
+    private static final ChatBoxConfigStorage INSTANCE = new ChatBoxConfigStorage();
+
+    public static ChatBoxConfigStorage getInstance() {
+        return INSTANCE;
+    }
+
     public static class General {
         public static final String NAME = "general";
 
@@ -98,12 +104,14 @@ public class ChatBoxConfigStorage implements IConfigHandler {
     }
 
     public static void loadFromFile() {
+        System.out.println("HIER LADEN FROM 1");
         File configFile =
                 FileUtils.getConfigDirectory().toPath().resolve("advancedchat").resolve(CONFIG_FILE_NAME).toFile();
 
         if (configFile.exists() && configFile.isFile() && configFile.canRead()) {
             JsonElement element = ConfigStorage.parseJsonFile(configFile);
-
+ 
+            System.out.println("HIER LADEN FROM FILE 2");
             if (element != null && element.isJsonObject()) {
                 JsonObject root = element.getAsJsonObject();
 
@@ -114,6 +122,8 @@ public class ChatBoxConfigStorage implements IConfigHandler {
                 ConfigStorage.applyRegistry(root.get(ChatSuggestorRegistry.NAME), ChatSuggestorRegistry.getInstance());
 
                 int version = JsonUtils.getIntegerOrDefault(root, "configVersion", 0);
+
+                System.out.println("HIER LADEN FROM FILE 3");
             }
         }
     }
@@ -138,6 +148,7 @@ public class ChatBoxConfigStorage implements IConfigHandler {
 
     @Override
     public void load() {
+        System.out.println("HIER LADEN LOAD");
         loadFromFile();
     }
 

--- a/src/main/java/io/github/darkkronicle/advancedchatbox/config/ChatBoxConfigStorage.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatbox/config/ChatBoxConfigStorage.java
@@ -22,6 +22,7 @@ import fi.dy.masa.malilib.util.StringUtils;
 import io.github.darkkronicle.advancedchatbox.AdvancedChatBox;
 import io.github.darkkronicle.advancedchatbox.registry.ChatFormatterRegistry;
 import io.github.darkkronicle.advancedchatbox.registry.ChatSuggestorRegistry;
+import io.github.darkkronicle.advancedchatbox.suggester.SpellCheckSuggestor;
 import io.github.darkkronicle.advancedchatcore.config.ConfigStorage;
 import io.github.darkkronicle.advancedchatcore.config.SaveableConfig;
 import io.github.darkkronicle.advancedchatcore.config.options.ConfigColor;
@@ -70,9 +71,13 @@ public class ChatBoxConfigStorage implements IConfigHandler {
                 .fromConfig("availableSuggestionColor", new ConfigColor(translate("availablesuggestioncolor"),
                         new Color(150, 150, 150, 255), translate("info.availablesuggestioncolor")));
 
+        public static final SaveableConfig<ConfigString> SPELL_LANGUAGE = SaveableConfig.fromConfig("spellLanguage",
+                new ConfigString(translate("spellLanguage"), "German", translate("info.spellLanguage")));
+        
+
         public static final ImmutableList<SaveableConfig<? extends IConfigBase>> OPTIONS =
                 ImmutableList.of(HIGHLIGHT_COLOR, UNHIGHLIGHT_COLOR, BACKGROUND_COLOR, SUGGESTION_SIZE,
-                        REMOVE_IDENTIFIER, PRUNE_PLAYER_SUGGESTIONS, AVAILABLE_SUGGESTION_COLOR);
+                        REMOVE_IDENTIFIER, PRUNE_PLAYER_SUGGESTIONS, AVAILABLE_SUGGESTION_COLOR, SPELL_LANGUAGE);
     }
 
     public static class SpellChecker {
@@ -84,8 +89,6 @@ public class ChatBoxConfigStorage implements IConfigHandler {
 
         public static final SaveableConfig<ConfigString> HOVER_TEXT = SaveableConfig.fromConfig("hoverText",
                 new ConfigString(translate("hovertext"), "&7$1&b$2&7$3", translate("info.hovertext")));
-        public static final SaveableConfig<ConfigString> SPELL_LANGUAGE = SaveableConfig.fromConfig("spellLanguage",
-                new ConfigString(translate("spellLanguage"), "German", translate("info.spellLanguage")));       
 
         // public static final SaveableConfig<ConfigBoolean>
         // SUGGEST_CAPITAL =
@@ -98,20 +101,18 @@ public class ChatBoxConfigStorage implements IConfigHandler {
         // )
         // );
 
-        public static final ImmutableList<SaveableConfig<? extends IConfigBase>> OPTIONS = ImmutableList.of(HOVER_TEXT, SPELL_LANGUAGE
+        public static final ImmutableList<SaveableConfig<? extends IConfigBase>> OPTIONS = ImmutableList.of(HOVER_TEXT
         // SUGGEST_CAPITAL
         );
     }
 
     public static void loadFromFile() {
-        System.out.println("HIER LADEN FROM 1");
         File configFile =
                 FileUtils.getConfigDirectory().toPath().resolve("advancedchat").resolve(CONFIG_FILE_NAME).toFile();
 
         if (configFile.exists() && configFile.isFile() && configFile.canRead()) {
             JsonElement element = ConfigStorage.parseJsonFile(configFile);
  
-            System.out.println("HIER LADEN FROM FILE 2");
             if (element != null && element.isJsonObject()) {
                 JsonObject root = element.getAsJsonObject();
 
@@ -123,7 +124,6 @@ public class ChatBoxConfigStorage implements IConfigHandler {
 
                 int version = JsonUtils.getIntegerOrDefault(root, "configVersion", 0);
 
-                System.out.println("HIER LADEN FROM FILE 3");
             }
         }
     }
@@ -148,8 +148,8 @@ public class ChatBoxConfigStorage implements IConfigHandler {
 
     @Override
     public void load() {
-        System.out.println("HIER LADEN LOAD");
         loadFromFile();
+        SpellCheckSuggestor.getInstance().setup();        
     }
 
     @Override

--- a/src/main/java/io/github/darkkronicle/advancedchatbox/config/ChatBoxConfigStorage.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatbox/config/ChatBoxConfigStorage.java
@@ -72,7 +72,7 @@ public class ChatBoxConfigStorage implements IConfigHandler {
                         new Color(150, 150, 150, 255), translate("info.availablesuggestioncolor")));
 
         public static final SaveableConfig<ConfigString> SPELL_LANGUAGE = SaveableConfig.fromConfig("spellLanguage",
-                new ConfigString(translate("spellLanguage"), "German", translate("info.spellLanguage")));
+                new ConfigString(translate("spellLanguage"), "American", translate("info.spellLanguage")));
         
 
         public static final ImmutableList<SaveableConfig<? extends IConfigBase>> OPTIONS =

--- a/src/main/java/io/github/darkkronicle/advancedchatbox/suggester/SpellCheckSuggestor.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatbox/suggester/SpellCheckSuggestor.java
@@ -30,26 +30,42 @@ import net.minecraft.text.Text;
 import org.languagetool.JLanguageTool;
 import org.languagetool.ResultCache;
 import org.languagetool.UserConfig;
+import org.languagetool.language.GermanyGerman;
 import org.languagetool.language.AmericanEnglish;
+import org.languagetool.language.BritishEnglish;
 import org.languagetool.rules.RuleMatch;
 
 @Environment(EnvType.CLIENT)
 public class SpellCheckSuggestor implements IMessageSuggestor {
-    private final JLanguageTool lt;
-
-    private static final SpellCheckSuggestor INSTANCE = new SpellCheckSuggestor();
+    String selectedLanguage = ChatBoxConfigStorage.SpellChecker.SPELL_LANGUAGE.config.getStringValue();
+    private JLanguageTool language;
+    //System.out.println("Ausserhalb von SpellCheckSuggestor: selectedLanguage:"+selectedLanguage+" language:"+language);
+    private static SpellCheckSuggestor INSTANCE = new SpellCheckSuggestor();
 
     public static SpellCheckSuggestor getInstance() {
         return INSTANCE;
     }
-
     private SpellCheckSuggestor() {
-        lt = new JLanguageTool(new AmericanEnglish(), new AmericanEnglish(), new ResultCache(15),
-                new UserConfig(new ArrayList<>(), new HashMap<>(), 20));
-        lt.setMaxErrorsPerWordRate(0.33f);
+        //selectedLanguage = "British";
+        //System.out.println("Innerhalb von SpellCheckSuggestor: selectedLanguage:"+selectedLanguage+" language:"+language);
+        switch (selectedLanguage) {
+        
+        case "German": language = new JLanguageTool(new GermanyGerman(), new GermanyGerman(), new ResultCache(15),
+             new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+        
+        case "British": language = new JLanguageTool(new BritishEnglish(), new BritishEnglish(), new ResultCache(15),
+             new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+        
+        case "American": language = new JLanguageTool(new AmericanEnglish(), new AmericanEnglish(), new ResultCache(15),
+            new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+        default: language = new JLanguageTool(new BritishEnglish(), new BritishEnglish(), new ResultCache(15),
+        new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+        }
+
+        language.setMaxErrorsPerWordRate(0.33f);
         try {
             // Set it up. Make it so it doesn't freeze later.
-            lt.check("a");
+            language.check("a");
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -59,7 +75,7 @@ public class SpellCheckSuggestor implements IMessageSuggestor {
     public Optional<List<AdvancedSuggestions>> suggest(String text) {
         ArrayList<AdvancedSuggestions> suggestions = new ArrayList<>();
         try {
-            List<RuleMatch> matches = lt.check(text);
+            List<RuleMatch> matches = language.check(text);
             for (RuleMatch match : matches) {
                 int fromPos = match.getFromPos();
                 int toPos = match.getToPos();

--- a/src/main/java/io/github/darkkronicle/advancedchatbox/suggester/SpellCheckSuggestor.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatbox/suggester/SpellCheckSuggestor.java
@@ -45,31 +45,34 @@ public class SpellCheckSuggestor implements IMessageSuggestor {
     public static SpellCheckSuggestor getInstance() {
         return INSTANCE;
     }
-    private SpellCheckSuggestor() {
-        //selectedLanguage = "British";
-        //System.out.println("Innerhalb von SpellCheckSuggestor: selectedLanguage:"+selectedLanguage+" language:"+language);
-        switch (selectedLanguage) {
+    public SpellCheckSuggestor() {
         
-        case "German": language = new JLanguageTool(new GermanyGerman(), new GermanyGerman(), new ResultCache(15),
-             new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
-        
-        case "British": language = new JLanguageTool(new BritishEnglish(), new BritishEnglish(), new ResultCache(15),
-             new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
-        
-        case "American": language = new JLanguageTool(new AmericanEnglish(), new AmericanEnglish(), new ResultCache(15),
-            new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
-        default: language = new JLanguageTool(new BritishEnglish(), new BritishEnglish(), new ResultCache(15),
-        new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
-        }
-
-        language.setMaxErrorsPerWordRate(0.33f);
-        try {
-            // Set it up. Make it so it doesn't freeze later.
-            language.check("a");
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
     }
+    public void Setup() {
+            
+        //selectedLanguage = "British";
+        switch (selectedLanguage) {
+    
+       case "German": language = new JLanguageTool(new GermanyGerman(), new GermanyGerman(), new ResultCache(15),
+            new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+       
+       case "British": language = new JLanguageTool(new BritishEnglish(), new BritishEnglish(), new ResultCache(15),
+            new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+       
+       case "American": language = new JLanguageTool(new AmericanEnglish(), new AmericanEnglish(), new ResultCache(15),
+           new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+       default: language = new JLanguageTool(new BritishEnglish(), new BritishEnglish(), new ResultCache(15),
+       new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+       }
+
+       language.setMaxErrorsPerWordRate(0.33f);
+       try {
+           // Set it up. Make it so it doesn't freeze later.
+           language.check("a");
+       } catch (IOException e) {
+           e.printStackTrace();
+       }
+    } 
 
     @Override
     public Optional<List<AdvancedSuggestions>> suggest(String text) {

--- a/src/main/java/io/github/darkkronicle/advancedchatbox/suggester/SpellCheckSuggestor.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatbox/suggester/SpellCheckSuggestor.java
@@ -45,10 +45,10 @@ public class SpellCheckSuggestor implements IMessageSuggestor {
     public static SpellCheckSuggestor getInstance() {
         return INSTANCE;
     }
-    public SpellCheckSuggestor() {
+    private SpellCheckSuggestor() {
         
     }
-    public void Setup() {
+    public void setup() {
             
         //selectedLanguage = "British";
         switch (selectedLanguage) {

--- a/src/main/java/io/github/darkkronicle/advancedchatbox/suggester/SpellCheckSuggestor.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatbox/suggester/SpellCheckSuggestor.java
@@ -36,8 +36,7 @@ import org.languagetool.language.BritishEnglish;
 import org.languagetool.rules.RuleMatch;
 
 @Environment(EnvType.CLIENT)
-public class SpellCheckSuggestor implements IMessageSuggestor {
-    String selectedLanguage = ChatBoxConfigStorage.SpellChecker.SPELL_LANGUAGE.config.getStringValue();
+public class SpellCheckSuggestor implements IMessageSuggestor {    
     private JLanguageTool language;
     //System.out.println("Ausserhalb von SpellCheckSuggestor: selectedLanguage:"+selectedLanguage+" language:"+language);
     private static SpellCheckSuggestor INSTANCE = new SpellCheckSuggestor();
@@ -49,7 +48,7 @@ public class SpellCheckSuggestor implements IMessageSuggestor {
         
     }
     public void setup() {
-            
+        String selectedLanguage = ChatBoxConfigStorage.SpellChecker.SPELL_LANGUAGE.config.getStringValue();    
         //selectedLanguage = "British";
         switch (selectedLanguage) {
     

--- a/src/main/java/io/github/darkkronicle/advancedchatbox/suggester/SpellCheckSuggestor.java
+++ b/src/main/java/io/github/darkkronicle/advancedchatbox/suggester/SpellCheckSuggestor.java
@@ -33,22 +33,33 @@ import org.languagetool.UserConfig;
 import org.languagetool.language.GermanyGerman;
 import org.languagetool.language.AmericanEnglish;
 import org.languagetool.language.BritishEnglish;
+import org.languagetool.language.Russian;
+import org.languagetool.language.Chinese; 
+import org.languagetool.language.PortugalPortuguese; 
+import org.languagetool.language.French; 
+import org.languagetool.language.Dutch; 
+import org.languagetool.language.Polish; 
+import org.languagetool.language.Spanish; 
+import org.languagetool.language.Italian; 
+import org.languagetool.language.Ukrainian; 
 import org.languagetool.rules.RuleMatch;
 
 @Environment(EnvType.CLIENT)
-public class SpellCheckSuggestor implements IMessageSuggestor {    
+public class SpellCheckSuggestor implements IMessageSuggestor {
     private JLanguageTool language;
-    //System.out.println("Ausserhalb von SpellCheckSuggestor: selectedLanguage:"+selectedLanguage+" language:"+language);
     private static SpellCheckSuggestor INSTANCE = new SpellCheckSuggestor();
 
     public static SpellCheckSuggestor getInstance() {
         return INSTANCE;
     }
+    
+
     private SpellCheckSuggestor() {
         
     }
     public void setup() {
-        String selectedLanguage = ChatBoxConfigStorage.SpellChecker.SPELL_LANGUAGE.config.getStringValue();    
+        String selectedLanguage = ChatBoxConfigStorage.General.SPELL_LANGUAGE.config.getStringValue();
+        System.out.println("HIER LADEN SPRACHE"+selectedLanguage); 
         //selectedLanguage = "British";
         switch (selectedLanguage) {
     
@@ -60,7 +71,38 @@ public class SpellCheckSuggestor implements IMessageSuggestor {
        
        case "American": language = new JLanguageTool(new AmericanEnglish(), new AmericanEnglish(), new ResultCache(15),
            new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
-       default: language = new JLanguageTool(new BritishEnglish(), new BritishEnglish(), new ResultCache(15),
+       
+       case "Russian": language = new JLanguageTool(new Russian(), new Russian(), new ResultCache(15),
+           new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+
+       case "Chinese": language = new JLanguageTool(new Chinese(), new Chinese(), new ResultCache(15),
+           new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;   
+           
+       case "Portuguese": language = new JLanguageTool(new PortugalPortuguese(), new PortugalPortuguese(), new ResultCache(15),
+           new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+
+       case "French": language = new JLanguageTool(new French(), new French(), new ResultCache(15),
+           new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+
+       case "Dutch": language = new JLanguageTool(new Dutch(), new Dutch(), new ResultCache(15),
+           new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+
+       case "Polish": language = new JLanguageTool(new Polish(), new Polish(), new ResultCache(15),
+           new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+
+       case "Spanish": language = new JLanguageTool(new Spanish(), new Spanish(), new ResultCache(15),
+           new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+
+       case "Italian": language = new JLanguageTool(new Italian(), new Italian(), new ResultCache(15),
+           new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+
+       case "Ukrainian": language = new JLanguageTool(new Ukrainian(), new Ukrainian(), new ResultCache(15),
+           new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
+           
+
+
+
+       default: language = new JLanguageTool(new AmericanEnglish(), new AmericanEnglish(), new ResultCache(15),
        new UserConfig(new ArrayList<>(), new HashMap<>(), 20)); break;
        }
 

--- a/src/main/resources/assets/advancedchatbox/lang/en_us.json
+++ b/src/main/resources/assets/advancedchatbox/lang/en_us.json
@@ -47,6 +47,8 @@
   "advancedchatbox.config.general.info.pruneplayersuggestions": "Whether or not §6non-real players§r, such as the fake players used in BungeeTabListPlus, are removed from the §dChatSuggestor",
   "advancedchatbox.config.general.availablesuggestioncolor": "Available Suggestion Color",
   "advancedchatbox.config.general.info.availablesuggestioncolor": "What color §6custom chat suggestors§r will show up as",
+  "advancedchatbox.config.general.spellLanguage": "Spellcheck Language",
+  "advancedchatbox.config.general.info.spellLanguage": "What language to §6spellcheck§r in",  
   "advancedchatbox.config.spellchecker.hovertext": "Spell Checker Hover Format",
   "advancedchatbox.config.spellchecker.info.hovertext": "The format of the text that appears when you hover your mouse over a suggested spelling change\n§b$1§r is the first part of the description, up to the suggested change\n§b$2§r is the actual spelling suggestion\n§b$3§r is any additional information that the spell checker may provide"
 }


### PR DESCRIPTION
List of Supported Languages:

- American (English)
- British (English)
- German
- French
- Italian
- Portuguese
- Spanish
- Dutch
- Polish
- Ukrainian
- Russian
- Chinese

